### PR TITLE
Treat empty licences as restricted

### DIFF
--- a/src/main/java/org/eclipse/dash/licenses/LicenseSupport.java
+++ b/src/main/java/org/eclipse/dash/licenses/LicenseSupport.java
@@ -106,7 +106,7 @@ public class LicenseSupport {
 	 *         <code>Status.Restricted</code> otherwise
 	 */
 	public Status getStatus(String expression) {
-		if (expression == null)
+		if (expression == null || expression.trim().isEmpty())
 			return Status.Restricted;
 
 		if (new SpdxExpressionParser().parse(expression).matchesApproved(approvedLicenses.keySet())) {


### PR DESCRIPTION
When running with a lower confidence value, there can be cases where the License specified in ClearlyDefined is empty (e.g. https://clearlydefined.io/definitions/maven/mavencentral/jrms/jrms/1.1). In such cases, `LicenseSupport#getStatus(String expression)` will throw a `NullPointerException` when trying to match the license with an approved one. With this PR, an empty license is treated like a `null` value and rejected immediately.