### PR TITLE
Skip empty lines in dependency lists

### DIFF
--- a/src/main/java/org/eclipse/dash/licenses/cli/FlatFileReader.java
+++ b/src/main/java/org/eclipse/dash/licenses/cli/FlatFileReader.java
@@ -37,7 +37,7 @@ public class FlatFileReader implements IDependencyListReader {
 
 	@Override
 	public List<IContentId> getContentIds() {
-		return reader.lines().map(line -> getContentId(line)).collect(Collectors.toList());
+		return reader.lines().filter(line -> !line.isBlank()).map(this::getContentId).collect(Collectors.toList());
 	}
 
 	public IContentId getContentId(String value) {

--- a/src/main/java/org/eclipse/dash/licenses/cli/NeedsReviewCollector.java
+++ b/src/main/java/org/eclipse/dash/licenses/cli/NeedsReviewCollector.java
@@ -44,7 +44,7 @@ public class NeedsReviewCollector implements IResultsCollector {
 			output.println(
 					"Vetted license information was found for all content. No further investigation is required.");
 		} else {
-			output.println("License information could not automatically verified for the following content:");
+			output.println("License information could not be automatically verified for the following content:");
 			output.println();
 			needsReview.forEach(data -> output.println(data.getId() + " (" + data.getLicense() + ")"));
 			output.println();


### PR DESCRIPTION
The checker created entries in the output that were not easy to
understand for empty lines in the input file(s).