### PR TITLE
Add a generic parser for Clearly Defined identifiers

### DIFF
--- a/src/main/java/org/eclipse/dash/licenses/ClearlyDefinedIdParser.java
+++ b/src/main/java/org/eclipse/dash/licenses/ClearlyDefinedIdParser.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.dash.licenses;
+
+import java.util.Optional;
+
+/**
+ * A parser for Clearly Defined identifiers.
+ *
+ */
+public class ClearlyDefinedIdParser implements ContentIdParser {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Optional<IContentId> parseId(String input) {
+		if (input == null || input.isEmpty()) {
+			return Optional.empty();
+		}
+		return Optional.of(ContentId.getContentId(input));
+	}
+}

--- a/src/main/java/org/eclipse/dash/licenses/cli/FlatFileReader.java
+++ b/src/main/java/org/eclipse/dash/licenses/cli/FlatFileReader.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.eclipse.dash.licenses.ClearlyDefinedIdParser;
 import org.eclipse.dash.licenses.ContentIdParser;
 import org.eclipse.dash.licenses.IContentId;
 import org.eclipse.dash.licenses.InvalidContentId;
@@ -33,6 +34,7 @@ public class FlatFileReader implements IDependencyListReader {
 		reader = new BufferedReader(input);
 		parsers.add(new MavenIdParser());
 		parsers.add(new NpmJsIdParser());
+		parsers.add(new ClearlyDefinedIdParser());
 	}
 
 	@Override


### PR DESCRIPTION
Some dependencies cannot be expressed as part of the build system being
used. For example if a Maven based build requires a Mongo DB instance
running, then the POM would contain a dependency for the MongoDB client
but not for the DB itself. However, a Clearly Defined identifier for the
MongoDB source code location or archive could instead be fed into the
License Checker in such a case.