### PR TITLE
Add UPL-1.0 to list of supported EF licenses

### DIFF
--- a/src/main/java/org/eclipse/dash/licenses/LicenseSupport.java
+++ b/src/main/java/org/eclipse/dash/licenses/LicenseSupport.java
@@ -87,6 +87,10 @@ public class LicenseSupport {
 		licenses.put("UNLICENSE", "Unlicense");
 		licenses.put("ARTISTIC-2.0", "Artistic-2.0");
 		licenses.put("BSD-2-Clause-FreeBSD", "BSD 2-Clause FreeBSD License");
+		// see https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21894
+		// TODO it would probably be better to add this license to
+		// the official list at https://www.eclipse.org/legal/licenses.json
+		licenses.put("UPL-1.0", "Universal Permissive License v1.0");
 		return licenses;
 	}
 


### PR DESCRIPTION
According to Sharon's comment on [1] it looks like UPL-1.0 should actually be added to [2]. However, for the time being, it should suffice to add it locally.

[1] https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21894#c12
[2] https://www.eclipse.org/legal/licenses.json