### PR TITLE
Hint for using grep on Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ The output (for now) is either a statement that the licenses for all of the cont
 been identified and verified, or a list of those dependencies that require further
 scrutiny.
 
+**Note for Mac users:** `grep` command on Mac doesn't support parameter option `-P` hence `grep -Poh "\S+:(system|provided|compile)"` will fail.
+Use `-E` option instead i.e. `grep -ohE "\S+:(system|provided|compile)"` or install GNU grep on your Mac via the command:
+
+```
+$ brew install grep
+```
+
+Afterwards `grep` will be accessible via `ggrep` so `ggrep -Poh "\S+:(system|provided|compile)` will do the trick.
+
 ### Example: Maven
 
 ```


### PR DESCRIPTION
I stumbled upon same `grep` issue as mentioned in https://github.com/eclipse/dash-licenses/issues/5. Since there seems to be no progress within https://github.com/eclipse/dash-licenses/pull/11 I lend a hand to get this fixed

Resolves #5