### PR TITLE
Fix NPE in LicenseSupport

### DIFF
--- a/core/src/main/java/org/eclipse/dash/licenses/context/DefaultContext.java
+++ b/core/src/main/java/org/eclipse/dash/licenses/context/DefaultContext.java
@@ -42,10 +42,10 @@ public class DefaultContext implements IContext {
 
 		licenseCheckerService = new LicenseChecker(this);
 		gitlabService = new GitLabSupport(this);
+		httpClientService = new HttpClientService(this);
 		licenseService = new LicenseSupport(this);
 		npmjsPackageService = new NpmjsPackageService(this);
 
-		httpClientService = new HttpClientService(this);
 	}
 
 	@Override


### PR DESCRIPTION
Experienced via the maven plugin.
In DefaultContext constructor httpClientService is created after
LicenseSupport but licenseSuport constructor requests
getHttpClientService which is still null at that point.
Reordering the creation order in DefaultContext fixes the issue.

Signed-off-by: Alexander Kurtakov <akurtako@redhat.com>