### PR TITLE
Minor README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ This content is either not correctly mapped by the system, or requires review.
 We provide a tool to generate a dependency list for yarn-based builds.
 
 ```
-$ (cd <path-to-this-repo>yarn && yarn install)
+$ (cd <path-to-this-repo>/yarn && yarn install)
 $ (cd <path-to-project> && node <path-to-this-repo>/yarn/index.js) \
  | java -jar org.eclipse.dash.licenses-<version>.jar -
 ```

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The tool incorporates a new experimental feature that leverages some new technol
 
 To use this feature, you must have committer status on at least one Eclipse project.
 
-* Get an [authentication token](https://gitlab.eclipse.org/-/profile/personal_access_tokens) from `gitlab.eclipse.org`;
+* Get an [authentication token](https://gitlab.eclipse.org/-/profile/personal_access_tokens) (scope: `api`) from `gitlab.eclipse.org`;
 * Include the `-review` option;
 * Pass the token via the `-token` option; and
 * Pass the project id via the `-project` option.


### PR DESCRIPTION
Aligns with the next line where '/' is explicitly added after
"\<path-to-this-repo\>". Without this, I first interpreted as :

```
cd <path-to-this-repo>
yarn && yarn install
```

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>