### PR TITLE
license-check goal should log warn/error if review is needed.

### DIFF
--- a/maven-plugin/src/main/java/org/eclipse/dash/licenses/maven/LicenseCheckMojo.java
+++ b/maven-plugin/src/main/java/org/eclipse/dash/licenses/maven/LicenseCheckMojo.java
@@ -205,12 +205,22 @@ public class LicenseCheckMojo extends AbstractArtifactFilteringMojo {
 		});
 		collectors.forEach(IResultsCollector::close);
 
+		boolean reviewNeeded = needsReviewCollector.getStatus() > 0;
+
 		// Pass the output from the first collector to the maven log
 		try (BufferedReader primaryReader = new BufferedReader(
 				new InputStreamReader(new ByteArrayInputStream(primaryOut.toByteArray()), StandardCharsets.UTF_8))) {
 			String line = null;
 			while ((line = primaryReader.readLine()) != null) {
-				getLog().info(line);
+				if (reviewNeeded) {
+					if (failWhenReviewNeeded) {
+						getLog().error(line);
+					} else {
+						getLog().warn(line);
+					}
+				} else {
+					getLog().info(line);
+				}
 			}
 		} catch (IOException e) {
 			throw new MojoExecutionException(e.getMessage(), e);
@@ -218,7 +228,7 @@ public class LicenseCheckMojo extends AbstractArtifactFilteringMojo {
 
 		getLog().info("Summary file was written to: " + summary);
 		
-		if (failWhenReviewNeeded && needsReviewCollector.getStatus() > 0) {
+		if (reviewNeeded && failWhenReviewNeeded) {
 			getLog().error("Dependency license check failed. Some dependencies need to be vetted.");
 			throw new MojoFailureException("Some dependencies must be vetted.");
 		}


### PR DESCRIPTION
Use WARNING level for log when review is needed.
```
[INFO] --- license-tool-plugin:0.0.1-SNAPSHOT:license-check (default-cli) @ leshan ---
[INFO] Querying Eclipse Foundation for license data for 21 items.
[INFO] Found 14 items.
[INFO] Querying ClearlyDefined for license data for 7 items.
[INFO] Found 7 items.
[WARNING] License information could not be automatically verified for the following content:
[WARNING] 
[WARNING] maven/mavencentral/gnu-regexp/gnu-regexp/1.1.4
[WARNING] 
[WARNING] This content is either not correctly mapped by the system, or requires review.
[WARNING] 
[WARNING] 
[INFO] Summary file was written to: /home/sbernard/git/leshan/target/dash/summary
[INFO] ------------------------------------------------------------------------
```

Use ERROR level for  log when review is needed and `failWhenReviewNeeded=true`
```
[INFO] --- license-tool-plugin:0.0.1-SNAPSHOT:license-check (default-cli) @ leshan ---
[INFO] Querying Eclipse Foundation for license data for 21 items.
[INFO] Found 14 items.
[INFO] Querying ClearlyDefined for license data for 7 items.
[INFO] Found 7 items.
[ERROR] License information could not be automatically verified for the following content:
[ERROR] 
[ERROR] maven/mavencentral/gnu-regexp/gnu-regexp/1.1.4
[ERROR] 
[ERROR] This content is either not correctly mapped by the system, or requires review.
[ERROR] 
[ERROR] 
[INFO] Summary file was written to: /home/sbernard/git/leshan/target/dash/summary
[ERROR] Dependency license check failed. Some dependencies need to be vetted.
[INFO] ------------------------------------------------------------------------
```

else use INFO level for log : 
```
[INFO] --- license-tool-plugin:0.0.1-SNAPSHOT:license-check (default-cli) @ leshan ---
[INFO] Querying Eclipse Foundation for license data for 42 items.
[INFO] Found 36 items.
[INFO] Querying ClearlyDefined for license data for 6 items.
[INFO] Found 6 items.
[INFO] Vetted license information was found for all content. No further investigation is required.
[INFO] Summary file was written to: /home/sbernard/git/leshan/target/dash/summary
[INFO] ------------------------------------------------------------------------
```