### PR TITLE
Add VERIFY as defaultPhase to license-check goal (maven plugin)

### DIFF
--- a/maven-plugin/src/main/java/org/eclipse/dash/licenses/maven/LicenseCheckMojo.java
+++ b/maven-plugin/src/main/java/org/eclipse/dash/licenses/maven/LicenseCheckMojo.java
@@ -28,6 +28,7 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -49,7 +50,7 @@ import com.google.inject.Injector;
 /**
  * Maven goal for running the Dash License Check tool.
  */
-@Mojo(name = "license-check", requiresProject = true, aggregator = true, requiresDependencyResolution = ResolutionScope.TEST, inheritByDefault = false)
+@Mojo(name = "license-check", requiresProject = true, aggregator = true, requiresDependencyResolution = ResolutionScope.TEST, inheritByDefault = false, defaultPhase = LifecyclePhase.VERIFY)
 public class LicenseCheckMojo extends AbstractArtifactFilteringMojo {
 
 	/**


### PR DESCRIPTION
Looking at [Mojo Documentation](https://maven.apache.org/developers/mojo-api-specification.html#the-descriptor-and-annotations), I see that we can define a default phase. 

>  Defines a default phase to bind a mojo execution to if the user does not explicitly set a phase in the POM.
    Note: This annotation will not automagically make a mojo run when the plugin declaration is added  to the POM. It merely enables the user to omit the <phase> element from the surrounding  <execution> element.

If this PR makes sense and if wanted I can also change the [README](https://github.com/eclipse/dash-licenses#add-to-your-maven-build) and remove the `<phase>verify</phase>`

