### PR TITLE
Fix #109 - ensure license check mojo is not inherited

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -37,7 +37,7 @@
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>
 			<artifactId>maven-plugin-annotations</artifactId>
-			<version>3.6.1</version>
+			<version>3.6.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.shared</groupId>
@@ -56,12 +56,13 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-plugin-plugin</artifactId>
-				<version>3.6.1</version>
+				<version>3.6.4</version>
 			</plugin>
 		</plugins>
 		<pluginManagement>
 			<plugins>
-				<!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+				<!--This plugin's configuration is used to store Eclipse m2e settings 
+					only. It has no influence on the Maven build itself. -->
 				<plugin>
 					<groupId>org.eclipse.m2e</groupId>
 					<artifactId>lifecycle-mapping</artifactId>
@@ -95,4 +96,34 @@
 			</plugins>
 		</pluginManagement>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>run-its</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-invoker-plugin</artifactId>
+						<version>3.2.2</version>
+						<configuration>
+							<postBuildHookScript>verify</postBuildHookScript>
+							<goals>
+								<goal>verify</goal>
+							</goals>
+						</configuration>
+						<executions>
+							<execution>
+								<id>integration-test</id>
+								<goals>
+									<goal>install</goal>
+									<goal>run</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/maven-plugin/src/it/no-inherit-deprecation/moduleA/pom.xml
+++ b/maven-plugin/src/it/no-inherit-deprecation/moduleA/pom.xml
@@ -1,0 +1,20 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.dash.its</groupId>
+		<artifactId>non-inheritance-parent</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>moduleA</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+			<version>2.11.0</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/maven-plugin/src/it/no-inherit-deprecation/moduleB/pom.xml
+++ b/maven-plugin/src/it/no-inherit-deprecation/moduleB/pom.xml
@@ -1,0 +1,20 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.eclipse.dash.its</groupId>
+		<artifactId>non-inheritance-parent</artifactId>
+		<version>1.0.0-SNAPSHOT</version>
+	</parent>
+	<artifactId>moduleB</artifactId>
+
+	<dependencies>
+		<dependency>
+			<groupId>commons-lang</groupId>
+			<artifactId>commons-lang</artifactId>
+			<version>2.6</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/maven-plugin/src/it/no-inherit-deprecation/pom.xml
+++ b/maven-plugin/src/it/no-inherit-deprecation/pom.xml
@@ -1,0 +1,44 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>org.eclipse.dash.its</groupId>
+	<artifactId>non-inheritance-parent</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
+
+	<name>Test for license-check goal non-inheritance</name>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<modules>
+		<module>moduleA</module>
+		<module>moduleB</module>
+	</modules>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.dash</groupId>
+				<artifactId>license-tool-plugin</artifactId>
+				<version>@project.version@</version>
+				<configuration>
+					<summary>DEPS</summary>
+				</configuration>
+				<executions>
+					<execution>
+						<id>license-check</id>
+						<phase>verify</phase>
+						<goals>
+							<goal>license-check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/maven-plugin/src/it/no-inherit-deprecation/verify.bsh
+++ b/maven-plugin/src/it/no-inherit-deprecation/verify.bsh
@@ -1,0 +1,48 @@
+/*************************************************************************
+ * Copyright (c) 2022 Mat Booth and others
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution, and is available at https://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *************************************************************************/
+
+import java.io.*;
+import java.util.*;
+import java.util.jar.*;
+import java.util.regex.*;
+
+try
+{
+    File summary = new File( basedir, "DEPS" );
+    System.out.println( "Checking for existence of " + summary );
+    if ( !summary.isFile() )
+    {
+        System.out.println( "FAILURE!" );
+        return false;
+    }
+
+    File summaryA = new File( basedir, "moduleA/DEPS" );
+    System.out.println( "Checking for non-existence of " + summaryA );
+    if ( summaryA.isFile() )
+    {
+        System.out.println( "FAILURE!" );
+        return false;
+    }
+
+    File summaryB = new File( basedir, "moduleB/DEPS" );
+    System.out.println( "Checking for non-existence of " + summaryB );
+    if ( summaryB.isFile() )
+    {
+        System.out.println( "FAILURE!" );
+        return false;
+    }
+}
+catch( Throwable t )
+{
+    t.printStackTrace();
+    return false;
+}
+
+return true;

--- a/maven-plugin/src/main/java/org/eclipse/dash/licenses/maven/LicenseCheckMojo.java
+++ b/maven-plugin/src/main/java/org/eclipse/dash/licenses/maven/LicenseCheckMojo.java
@@ -1,5 +1,5 @@
 /*************************************************************************
- * Copyright (c) 2020, 2021 Red Hat Inc. and others
+ * Copyright (c) 2020, 2022 Red Hat Inc. and others
  *
  * This program and the accompanying materials are made available under
  * the terms of the Eclipse Public License 2.0 which accompanies this
@@ -49,7 +49,7 @@ import com.google.inject.Injector;
 /**
  * Maven goal for running the Dash License Check tool.
  */
-@Mojo(name = "license-check", requiresProject = true, aggregator = true, requiresDependencyResolution = ResolutionScope.TEST, inheritByDefault = false)
+@Mojo(name = "license-check", requiresProject = true, aggregator = true, requiresDependencyResolution = ResolutionScope.TEST)
 public class LicenseCheckMojo extends AbstractArtifactFilteringMojo {
 
 	/**
@@ -137,6 +137,13 @@ public class LicenseCheckMojo extends AbstractArtifactFilteringMojo {
 
 	@Override
 	public void execute() throws MojoExecutionException, MojoFailureException {
+		// We are aggregating the deps for all projects in the reactor, so we only need
+		// to execute once. This check ensures we run only during the build of the
+		// top-level reactor project and avoids duplicate invokations
+		if (!mavenSession.getCurrentProject().equals(mavenSession.getTopLevelProject())) {
+			return;
+		}
+
 		if (skip) {
 			getLog().info("Skipping dependency license check");
 			return;


### PR DESCRIPTION
The "inheritedByDefault" mojo annotation parameter is no longer used by
maven 3.8+ and the parameter was finally deprecated in maven-plugin-tools
version 3.6.2.

This causes repeat executions of the mojo in multi-module projects no
matter what we set "inheritedByDefault" to.

This change updates to latest maven-plugin-tools, removes usage of the
deprecated parameter and fixes the mojo to only run during execution of
the top level project in the reactor.

Also added an integration test.