### PR TITLE
Better support for Tycho p2. coordinates, fix for Tycho 2.7

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -64,6 +64,11 @@
 			<version>4.19.0</version>
 		</dependency>
 		<dependency>
+			<groupId>org.eclipse.tycho</groupId>
+			<artifactId>tycho-core</artifactId>
+			<version>2.7.0</version>
+		</dependency>
+		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
 			<version>5.8.2</version>

--- a/core/src/main/java/org/eclipse/dash/licenses/MavenIdParser.java
+++ b/core/src/main/java/org/eclipse/dash/licenses/MavenIdParser.java
@@ -12,6 +12,8 @@ package org.eclipse.dash.licenses;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.eclipse.tycho.TychoConstants;
+
 public class MavenIdParser implements ContentIdParser {
 
 	// @formatter:off
@@ -50,8 +52,8 @@ public class MavenIdParser implements ContentIdParser {
 		String artifactid = matcher.group("artifactid");
 		String version = matcher.group("version");
 
-		String type = groupid.startsWith("p2.eclipse-") ? "p2" : "maven";
-		String source = groupid.startsWith("p2.eclipse-") ? "orbit" : "mavencentral";
+		String type = groupid.startsWith(TychoConstants.P2_GROUPID_PREFIX) ? "p2" : "maven";
+		String source = groupid.startsWith(TychoConstants.P2_GROUPID_PREFIX) ? "orbit" : "mavencentral";
 
 		/*
 		 * So this is a complete hack. If we're looking at the Apache Ant bundle, then
@@ -59,7 +61,7 @@ public class MavenIdParser implements ContentIdParser {
 		 * may not work in the general case.
 		 */
 		// FIXME Find a more general solution
-		if ("p2.eclipse-plugin".equals(groupid) && "org.apache.ant".equals(artifactid)) {
+		if ("p2".equals(type) && "org.apache.ant".equals(artifactid)) {
 			Matcher classifierMatcher = antBundleClassifierPattern.matcher(matcher.group("classifier"));
 			if (classifierMatcher.matches()) {
 				type = "maven";

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -46,6 +46,11 @@
 			<version>3.2.0</version>
 		</dependency>
 		<dependency>
+			<groupId>org.eclipse.tycho</groupId>
+			<artifactId>tycho-core</artifactId>
+			<version>2.7.0</version>
+		</dependency>
+		<dependency>
 			<groupId>org.eclipse.dash</groupId>
 			<artifactId>org.eclipse.dash.licenses</artifactId>
 			<version>${project.version}</version>

--- a/maven-plugin/src/main/java/org/eclipse/dash/licenses/maven/LicenseCheckMojo.java
+++ b/maven-plugin/src/main/java/org/eclipse/dash/licenses/maven/LicenseCheckMojo.java
@@ -43,6 +43,7 @@ import org.eclipse.dash.licenses.cli.NeedsReviewCollector;
 import org.eclipse.dash.licenses.context.LicenseToolModule;
 import org.eclipse.dash.licenses.review.CreateReviewRequestCollector;
 import org.eclipse.dash.licenses.review.GitLabSupport;
+import org.eclipse.tycho.TychoConstants;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -174,9 +175,9 @@ public class LicenseCheckMojo extends AbstractArtifactFilteringMojo {
 		// Adapt dependency artifacts to dash content IDs
 		List<IContentId> deps = new ArrayList<>();
 		filteredArtifacts.stream().sorted().forEach(a -> {
-			String type = a.getGroupId().startsWith("p2.eclipse-") ? "p2" : "maven";
+			String type = a.getGroupId().startsWith(TychoConstants.P2_GROUPID_PREFIX) ? "p2" : "maven";
 			// TODO deps are not necessarily from orbit or maven central
-			String source = a.getGroupId().startsWith("p2.eclipse-") ? "orbit" : "mavencentral";
+			String source = a.getGroupId().startsWith(TychoConstants.P2_GROUPID_PREFIX) ? "orbit" : "mavencentral";
 			// TODO could get duplicates here if two artifact coords differ only by
 			// classifier
 			deps.add(ContentId.getContentId(type, source, a.getGroupId(), a.getArtifactId(), a.getVersion()));


### PR DESCRIPTION
The only assumption one can make for GAV coordinates originating from
Tycho is that they use a "p2." prefix. Other parts of the type are not
meant to be relied on and can change between Tycho versions.