### PR TITLE
Add reusable GH-workflow for Maven-project license checks

### DIFF
--- a/.github/actions/maven-license-check-action/action.yml
+++ b/.github/actions/maven-license-check-action/action.yml
@@ -1,0 +1,44 @@
+# *************************************************************************
+# * Copyright (c) 2022 Hannes Wellmann and others.
+# *
+# * This program and the accompanying materials are made available under
+# * the terms of the Eclipse Public License 2.0 which accompanies this
+# * distribution, and is available at https://www.eclipse.org/legal/epl-2.0
+# *
+# * SPDX-License-Identifier: EPL-2.0
+# *************************************************************************
+
+name: 'Check license vetting status'
+description: 'Checks if the licenses of all dependencies are vetted and requests a review in case required and wanted'
+inputs:
+  request-review:
+    description: ''
+    required: false
+  project-id:
+    description: ''
+    required: false
+outputs:
+  licenses-vetted: 
+    description: "True if all licenses are vetted, else false"
+    value: ${{ steps.license-check-with-review-request.outputs.build-succeeded }}
+runs:
+  using: "composite"
+  steps:
+    - run: |
+        mvnArgs="-U -B -ntp org.eclipse.dash:license-tool-plugin:license-check -Ddash.fail=true --settings $GITHUB_ACTION_PATH/licenseCheckMavenSettings.xml"
+        if [ ${{ inputs.request-review }} ]; then
+          mvn ${mvnArgs} -Ddash.iplab.token=$GITLAB_API_TOKEN -Ddash.projectId=${{ inputs.project-id }}
+          if [[ $? == 0 ]]; then # All licenses are vetted
+            echo "::set-output name=build-succeeded::$(echo 1)"
+          else
+            echo "::set-output name=build-succeeded::$(echo 0)"
+          fi
+        else
+          mvn ${mvnArgs}
+          if [[ $? != 0 ]]; then
+            echo "Committers can request a review by commenting '/request-license-review'"
+            exit 1
+          fi
+        fi
+      shell: bash {0} # do not fail-fast
+      id: license-check-with-review-request

--- a/.github/actions/maven-license-check-action/licenseCheckMavenSettings.xml
+++ b/.github/actions/maven-license-check-action/licenseCheckMavenSettings.xml
@@ -1,0 +1,29 @@
+<!--
+ * Copyright (C) 2022 Hannes Wellmann and others. 
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ * 
+ * SPDX-FileType: DOCUMENTATION
+ *
+ * SPDX-FileCopyrightText: 2019 Eclipse Foundation
+ * SPDX-License-Identifier: EPL-2.0
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+	<profiles>
+		<profile>
+			<id>dash-licenses-snapshots</id>
+			<pluginRepositories>
+				<pluginRepository>
+					<id>dash-licenses-snapshots</id>
+					<url>https://repo.eclipse.org/content/repositories/dash-licenses-snapshots/</url>
+				</pluginRepository>
+			</pluginRepositories>
+		</profile>
+	</profiles>
+	<activeProfiles>
+		<activeProfile>dash-licenses-snapshots</activeProfile>
+	</activeProfiles>
+</settings>

--- a/.github/workflows/mavenLicenseCheck.yml
+++ b/.github/workflows/mavenLicenseCheck.yml
@@ -1,0 +1,110 @@
+# *************************************************************************
+# * Copyright (c) 2022 Hannes Wellmann and others.
+# *
+# * This program and the accompanying materials are made available under
+# * the terms of the Eclipse Public License 2.0 which accompanies this
+# * distribution, and is available at https://www.eclipse.org/legal/epl-2.0
+# *
+# * SPDX-License-Identifier: EPL-2.0
+# *************************************************************************
+
+# This workflow will check for Maven projects if the licenses of all (transitive) dependencies are vetted.
+
+name: License vetting status check
+
+on:
+  workflow_call:
+    inputs:
+      projectId:
+        description: 'The "projectId" used when license vetting is requested'
+        type: string
+        required: false
+        default: ''
+      setupScript:
+        description: 'Optional bash script that is executed before the license check and is intended to prepare the checked out project if necessary'
+        type: string
+        required: false
+        default: ''
+    secrets:
+      gitlabAPIToken:
+        description: 'The authentication token (scope: api) from gitlab.eclipse.org of the calling repository. Only required if license vetting is requested'
+        required: false
+
+jobs:
+  check-licenses:
+    if: github.event_name == 'pull_request' || (github.event.issue.pull_request != '' && (github.event.comment.body == '/request-license-review'))
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set review request
+      run: echo "request-review=1" >> $GITHUB_ENV
+      if: github.event.issue.pull_request != '' && (github.event.comment.body == '/request-license-review')
+
+    - name: Process license-vetting request
+      if: ${{ env.request-review }}
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const payload = await github.rest.repos.getCollaboratorPermissionLevel({
+            ...context.repo, username: context.actor
+          });
+          const userPermission = payload?.data?.permission;
+          let reaction = 'rocket'
+          if (!(userPermission == 'write' || userPermission == 'admin')) { // not a committer
+            //Not a commiter -> abort workflow
+            core.setFailed("Only committers are permitted to request license vetting and ${context.actor} isn't one.")
+            reaction = '-1'
+          }
+          // react on comment to give early feedback that the request was understood
+          await github.rest.reactions.createForIssueComment({
+            ...context.repo, comment_id: context.payload?.comment?.id, content: reaction
+          });
+
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: 'maven'
+
+    - name: Prepare for license check
+      run: ${{ inputs.setupScript }}
+      if: ${{ inputs.setupScript !='' }}
+
+    - name: Check license vetting status (and ask for review if requested)
+      id: check-license-vetting
+      uses: eclipse/dash-licenses/.github/actions/maven-license-check-action@master
+      with:
+        request-review: ${{ env.request-review }}
+        project-id: ${{ inputs.projectId }}
+      env:
+        GITLAB_API_TOKEN: ${{ secrets.gitlabAPIToken }}
+
+    - name: Process license check results
+      if: ${{ env.request-review }}
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const fs = require('fs')
+          let commentBody = '> /request-license-review\n\n'
+          const licenesVetted = ${{ steps.check-license-vetting.outputs.licenses-vetted }}
+          if( licenesVetted ) {
+            commentBody += 'All licenses already successfully vetted.'
+          } else {
+            process.env.GITHUB_WORKSPACE
+            const reviewSummaryFile = process.env.GITHUB_WORKSPACE + '/target/dash/review-summary'
+            core.info("Read review summary at " + reviewSummaryFile)
+            if (fs.existsSync( reviewSummaryFile )) {
+              commentBody += 'License review request summary:\n```'
+              commentBody += fs.readFileSync(reviewSummaryFile, 'utf8').trim();
+              commentBody += '\n```\n'
+              commentBody += 'Re-run the license-vetting check from the Github Actions web-interface after the review concluded to update its status.'
+            } else {
+              core.setFailed("License vetting build failed, but no review summary file was written")
+              commentBody += 'Failed to request review of not vetted licenses:\n'
+              commentBody += context.serverUrl + "/" + process.env.GITHUB_REPOSITORY + "/actions/runs/" + context.runId
+            }
+          }
+          github.rest.issues.createComment({
+            issue_number: context.issue.number, ...context.repo, body: commentBody
+          })

--- a/README.md
+++ b/README.md
@@ -411,6 +411,47 @@ e.g.,
 npm list | grep -Poh "\S+@\d+(?:\.\d+){2}" | sort | uniq | LicenseFinder -
 ```
 
+### Reusable Github workflow for automatic license check and IP Team Review Requests 
+
+**EXPERIMENTAL**
+
+Eclipse projects that use Maven for building can use the following workflow to set up an automatic license vetting check for their project,
+that also allows committer to request automatic IP reviews via comments:
+
+```
+# This workflow will check for Maven projects if the licenses of all (transitive) dependencies are vetted.
+name: License vetting status check
+on:
+  push:
+    branches: 
+      - 'master'
+  pull_request:
+    branches: 
+     - 'master'
+  issue_comment:
+    types: [created]
+jobs:
+  call-license-check:
+    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
+    with:
+      projectId: <PROJECT-ID>
+    secrets:
+      gitlabAPIToken: ${{ secrets.M2E_GITLAB_API_TOKEN }}
+```
+Projects that have to be set up in advance can use the `setupScript` parameter to pass a script that is executed before the license-check build is started.
+
+On each pull-reqest event (i.e. a new PR is created or a new commit for it is pushed) the license-status of all project dependencies is checked automatically and in case unvetted licenses are found the check fails.
+Committers of that project can request a review from the IP team, by simply adding a comment with body `/request-license-review`.
+The github-actions bot reacts with a 'rocket' to indicate the request was understood and is processed.
+Attempts to request license review by non-committers are rejected with a thumps-down reaction.
+After the license-review build has terminated the github-action bot will reply with a comment to show the result of the license review request.
+Committers can later re-run this license-check workflow from the Github actions web-interface to check for license-status changes.
+
+#### Requirements
+- Maven based build
+- Root pom.xml must reside in the repository root
+- An [authentication token (scope: api) from gitlab.eclipse.org](README.md#automatic-ip-team-review-requests) has to be stored in the repositories secret store(Settings -> Scrects -> Actions) with name `M2E_GITLAB_API_TOKEN`.
+
 ## Advanced Scenarios
 
 Support for some advanced usage may vary between Maven and stand-alone execution.


### PR DESCRIPTION
With this PR I want to propose to add a reusable GH-workflow that performs the license-check for a Maven build and allows committers to issue license-vetting requests by commenting on a corresponding PR.

If a project want to use this workflow to only check the status of all dependency licenses it has to create the following workflow in its repo:

```
# This workflow will check for Maven projects if the licenses of all (transitive) dependencies are vetted.
name: License vetting status check
on:
  push:
    branches: 
      - 'master'
  pull_request:
    branches: 
      - 'master'
jobs:
  call-license-check:
    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
```
Every-time a new commit is pushed to the master branch or a PR is created or updated it is checked if the licenses of all dependencies are vetted. Of course the events events can be adjusted as desired.

If the committers of a project should additionally be able to request the review of uncovered licenses via a comment on a PR the following set up can be used.
```
# This workflow will check for Maven projects if the licenses of all (transitive) dependencies are vetted.
name: License vetting status check
on:
  push:
    branches: 
      - 'master'
  pull_request:
    branches: 
      - 'master'
  issue_comment:
    types: [created]
jobs:
  call-license-check:
    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
    with:
      projectId: technology.m2e
      setupScript: |
        mvn clean generate-sources -f m2e-maven-runtime/pom.xml -B -Dtycho.mode=maven -Pgenerate-osgi-metadata
    secrets:
      githubToken: ${{ secrets.GITHUB_TOKEN }}
      gitlabAPIToken: ${{ secrets.M2E_GITLAB_API_TOKEN }}
```
Such a workflow requires an authentication token (scope: api) from gitlab.eclipse.org in the secrets store of the calling repo or its organization, the token could for example be issued in the name of the organizations bot account.
This workflow is an example suited for the M2E project and also uses the optional `setupScript` input parameter to run a preparing build before the actual license vetting build. Such an authentication token is already requested for m2e: https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/1137

If the license vetting for a PR fails and the licenses are not vetted automagically after a while and committer wants to request a license review by the Eclipse Foundation EMO team all the committer must do is to add a comment with the following message:
`/request-license-review`

The license-check Maven build then starts again but the the additional parameters to request the review of uncovered licenses.
To indicate that the comment was understood by the workflow it reacts with a rocket on that comment as soon as the build has started and the commentator has the right to request the review. If the commentator does not have the rights the workflow aborts and reacts with a `-1/thumps-down`.

If the license check has completed and licenses are vetted the workflow reacts with an additional 'hooray' on the request comment, if not all licenses are vetted and a review was requested the workflow reacts with `eyes`. If the workflow failed due to another reason it adds a `-1/thumps-down`.

In case the review was requested the comment then looks like this:

![grafik](https://user-images.githubusercontent.com/44067969/162638639-adf87409-2823-4171-8d0c-b4ffb9e0f43e.png)

The following things could/should be improved:
- [x] Copyright header?
- [x] Add Documentation in the README.md 
- [ ] More (optional) customization. Could be done as needed.
- [x] If the `license-tool-plugin` would communicate the created license vetting requests in a way that could be better consumed by a script (reading it from the console is not that simple), e.g. by writing it to a dedicated file next to `target/dash/summary`, the workflow could add the summary of created license-vetting requests as a comment to the PR. But it should be done in a separate PR.
- [x] In case you don't want to use external actions for security reasons their relevant parts could be re-written using the [github-script Action](https://github.com/marketplace/actions/github-script)

