### PR TITLE
Fix stream Closing/Encoding and clean-up/simplify

### DIFF
--- a/core/src/main/java/org/eclipse/dash/licenses/cli/NeedsReviewCollector.java
+++ b/core/src/main/java/org/eclipse/dash/licenses/cli/NeedsReviewCollector.java
@@ -11,6 +11,7 @@ package org.eclipse.dash.licenses.cli;
 
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,7 +29,7 @@ public class NeedsReviewCollector implements IResultsCollector {
 	private List<LicenseData> needsReview = new ArrayList<>();
 
 	public NeedsReviewCollector(OutputStream out) {
-		output = new PrintWriter(out);
+		output = new PrintWriter(out, false, StandardCharsets.UTF_8);
 	}
 
 	@Override
@@ -46,8 +47,7 @@ public class NeedsReviewCollector implements IResultsCollector {
 		} else {
 			output.println("License information could not be automatically verified for the following content:");
 			output.println();
-			needsReview.stream().sorted((a, b) -> a.getId().compareTo(b.getId()))
-					.forEach(each -> output.println(each.getId()));
+			needsReview.stream().map(LicenseData::getId).sorted().forEach(output::println);
 			output.println();
 			output.println("This content is either not correctly mapped by the system, or requires review.");
 

--- a/core/src/main/java/org/eclipse/dash/licenses/review/CreateReviewRequestCollector.java
+++ b/core/src/main/java/org/eclipse/dash/licenses/review/CreateReviewRequestCollector.java
@@ -11,6 +11,7 @@ package org.eclipse.dash.licenses.review;
 
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,14 +26,14 @@ import org.eclipse.dash.licenses.cli.IResultsCollector;
  * a review request.
  */
 public class CreateReviewRequestCollector implements IResultsCollector {
-	GitLabSupport gitLab;
 
+	private GitLabSupport gitLab;
 	private PrintWriter output;
 	private List<LicenseData> needsReview = new ArrayList<>();
 
 	public CreateReviewRequestCollector(GitLabSupport gitLab, OutputStream out) {
 		this.gitLab = gitLab;
-		output = new PrintWriter(out);
+		output = new PrintWriter(out, false, StandardCharsets.UTF_8);
 	}
 
 	@Override


### PR DESCRIPTION
With this PR I want to propose the following improvements in the `LicenseCheckMojo` and the `IResultsCollectors`.

- Ensure opened file-streams are closed
- Ensure UTF-8 is used when encoding byte-streams
- Apply clean-ups/simplifications 