### PR TITLE
Improve license check workflow

### DIFF
--- a/.github/workflows/mavenLicenseCheck.yml
+++ b/.github/workflows/mavenLicenseCheck.yml
@@ -41,7 +41,7 @@ jobs:
       if: github.event.issue.pull_request != '' && (github.event.comment.body == '/request-license-review')
 
     - name: Process license-vetting request
-      if: ${{ env.request-review }}
+      if: env.request-review
       uses: actions/github-script@v6
       with:
         script: |
@@ -51,7 +51,7 @@ jobs:
           const userPermission = payload?.data?.permission;
           let reaction = 'rocket'
           if (!(userPermission == 'write' || userPermission == 'admin')) { // not a committer
-            //Not a commiter -> abort workflow
+            // Not a commiter -> abort workflow
             core.setFailed("Only committers are permitted to request license vetting and ${context.actor} isn't one.")
             reaction = '-1'
           }
@@ -69,7 +69,7 @@ jobs:
 
     - name: Prepare for license check
       run: ${{ inputs.setupScript }}
-      if: ${{ inputs.setupScript !='' }}
+      if: inputs.setupScript !=''
 
     - name: Check license vetting status (and ask for review if requested)
       id: check-license-vetting
@@ -81,7 +81,7 @@ jobs:
         GITLAB_API_TOKEN: ${{ secrets.gitlabAPIToken }}
 
     - name: Process license check results
-      if: ${{ env.request-review }}
+      if: env.request-review
       uses: actions/github-script@v6
       with:
         script: |
@@ -91,18 +91,28 @@ jobs:
           if( licenesVetted ) {
             commentBody += 'All licenses already successfully vetted.'
           } else {
-            process.env.GITHUB_WORKSPACE
+
+            const runURL = context.serverUrl + "/" + process.env.GITHUB_REPOSITORY + "/actions/runs/" + context.runId
+
             const reviewSummaryFile = process.env.GITHUB_WORKSPACE + '/target/dash/review-summary'
             core.info("Read review summary at " + reviewSummaryFile)
+            
             if (fs.existsSync( reviewSummaryFile )) {
-              commentBody += 'License review request summary:\n```'
-              commentBody += fs.readFileSync(reviewSummaryFile, 'utf8').trim();
-              commentBody += '\n```\n'
-              commentBody += 'Re-run the license-vetting check from the Github Actions web-interface after the review concluded to update its status.'
+              let content = fs.readFileSync( reviewSummaryFile, 'utf8').trim();
+              core.warning("License reviews:\n" + content)
+
+              commentBody += 'License review requests:\n'
+              let lines = content.split('\n')
+              for(var line = 0; line < lines.length; line++){
+                commentBody += ('- ' + lines[line] + '\n')
+              }
+              commentBody += '\nFrom run: ' + runURL + '\n'
+              commentBody += 'After all reviews have concluded, re-run the license-vetting check from the Github Actions web-interface to update its status.'
+
             } else {
               core.setFailed("License vetting build failed, but no review summary file was written")
               commentBody += 'Failed to request review of not vetted licenses:\n'
-              commentBody += context.serverUrl + "/" + process.env.GITHUB_REPOSITORY + "/actions/runs/" + context.runId
+              commentBody += runURL
             }
           }
           github.rest.issues.createComment({

--- a/.github/workflows/mavenLicenseCheck.yml
+++ b/.github/workflows/mavenLicenseCheck.yml
@@ -60,7 +60,18 @@ jobs:
             ...context.repo, comment_id: context.payload?.comment?.id, content: reaction
           });
 
+    # By default the git-ref checked out for events triggered by comments is 'refs/heads/master'
+    # and for events triggered by PR creation/updates the ref is 'refs/pull/<PR-number>/merge'.
+    # So by default only the master-branch would be considered when requesting license-reviews, but we want the PR's state.
+    # Unless the PR is closed, then we want the master-branch, which allows subsequent license review requests.
     - uses: actions/checkout@v3
+      # use default ref 'refs/pull/<PR-number>/merge' for PR-events and 'refs/heads/master' for comments if the PR is closed
+      if: github.event.issue.pull_request == '' || github.event.issue.state != 'open'
+    - uses: actions/checkout@v3
+      with:
+        ref: 'refs/pull/${{ github.event.issue.number }}/merge'
+      if: github.event.issue.pull_request != '' && github.event.issue.state == 'open'
+  
     - uses: actions/setup-java@v3
       with:
         java-version: '11'


### PR DESCRIPTION
This PR improves the just added license check workflow in the following two points:
- enhanced comment when license-review was requested. In he previous state the formatting was flawed and did not leverage the markdown syntax of the review-summary file content. Additionally a link to the workflow-run that requested the reviews was added
- use the `refs/pull/${{ github.event.issue.number }}/merge` git-ref on git checkout in a workflow run triggered by a request-review comment. By default for comment events the ref is `refs/heads/master` and would therefore ignore the PR's state. Only if the PR is closed the master-branch is considered to allow delayed license reviews.

@waynebeaton can you please again review this. Thank you!