### PR TITLE
Attach summary files and improve comment of license-check workflow

### DIFF
--- a/.github/workflows/mavenLicenseCheck.yml
+++ b/.github/workflows/mavenLicenseCheck.yml
@@ -51,8 +51,8 @@ jobs:
           const userPermission = payload?.data?.permission;
           let reaction = 'rocket'
           if (!(userPermission == 'write' || userPermission == 'admin')) { // not a committer
-            // Not a commiter -> abort workflow
-            core.setFailed("Only committers are permitted to request license vetting and ${context.actor} isn't one.")
+            // Not a committer -> abort workflow
+            core.setFailed("Only committers are permitted to request license vetting and " + context.actor + " isn't one.")
             reaction = '-1'
           }
           // react on comment to give early feedback that the request was understood
@@ -97,35 +97,47 @@ jobs:
       with:
         script: |
           const fs = require('fs')
-          let commentBody = '> /request-license-review\n\n'
+          
           const licenesVetted = ${{ steps.check-license-vetting.outputs.licenses-vetted }}
+          let commentBody = '> ' + context.payload.comment.body + '\n\n'
+          
           if( licenesVetted ) {
-            commentBody += 'All licenses already successfully vetted.'
+            commentBody += ':heavy_check_mark: All licenses already successfully vetted.\n'
           } else {
-
-            const runURL = context.serverUrl + "/" + process.env.GITHUB_REPOSITORY + "/actions/runs/" + context.runId
-
+            
             const reviewSummaryFile = process.env.GITHUB_WORKSPACE + '/target/dash/review-summary'
             core.info("Read review summary at " + reviewSummaryFile)
+            let content = "";
+            if ( fs.existsSync( reviewSummaryFile )) {
+              content = fs.readFileSync( reviewSummaryFile, {encoding: 'utf8'}).trim();
+            }
             
-            if (fs.existsSync( reviewSummaryFile )) {
-              let content = fs.readFileSync( reviewSummaryFile, 'utf8').trim();
-              core.warning("License reviews:\n" + content)
-
+            if ( content ) { // not empty
               commentBody += 'License review requests:\n'
-              let lines = content.split('\n')
+              const lines = content.split('\n')
               for(var line = 0; line < lines.length; line++){
                 commentBody += ('- ' + lines[line] + '\n')
               }
-              commentBody += '\nFrom run: ' + runURL + '\n'
-              commentBody += 'After all reviews have concluded, re-run the license-vetting check from the Github Actions web-interface to update its status.'
-
+              commentBody += '\n'
+              commentBody += 'After all reviews have concluded, re-run the license-vetting check from the Github Actions web-interface to update its status.\n'
+              
             } else {
-              core.setFailed("License vetting build failed, but no review summary file was written")
-              commentBody += 'Failed to request review of not vetted licenses:\n'
-              commentBody += runURL
+              core.setFailed("License vetting build failed, but no reviews are created")
+              commentBody += ':warning: Failed to request review of not vetted licenses.\n'
             }
           }
+          commentBody += '\n'
+          commentBody += 'Workflow run (with attached summary files):\n'
+          commentBody += context.serverUrl + "/" + process.env.GITHUB_REPOSITORY + "/actions/runs/" + context.runId
+          
           github.rest.issues.createComment({
             issue_number: context.issue.number, ...context.repo, body: commentBody
           })
+
+    - uses: actions/upload-artifact@v3
+      if: always() && env.request-review
+      with:
+        name: '${{ inputs.projectId }}-license-vetting-summary'
+        path: |
+          target/dash/review-summary
+          target/dash/summary

--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ The Maven Plugin has the following "-D" options:
 - `dash.iplab.token` - The access token for automatically creating IP Team review requests. **Do not share your access token.**
 - `dash.projectId` - The project id
 - `dash.summary` - The location (where) to generate the summary file.
+- `dash.review.summary` - The location (where) to generate the review-summary file.
 
 Note that the Maven plugin always generates the summary file. The default location is `${project.build.directory}/dash/summary`.
 


### PR DESCRIPTION
This PR improves the license-check workflow in the following points
- upload summary and review-summary file on review-request and mention
file attachments in comments
- treat empty summary-file like non-existing file
- fix use of context.actor variable
- minor clean-up

Additionally it mentions the 'dash.review.summary' property in the README.md.

@waynebeaton can you please again review this. Thanks in advance.