### PR TITLE
Use Java-17 and consider *.target files for .m2-repo chaching

### DIFF
--- a/.github/workflows/mavenLicenseCheck.yml
+++ b/.github/workflows/mavenLicenseCheck.yml
@@ -74,9 +74,16 @@ jobs:
   
     - uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
-        cache: 'maven'
+    - name: Cache local Maven repository
+      uses: actions/cache@v3
+      with:
+        path: ~/.m2/repository
+        # re-cache on changes in the pom and target files
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '**/*.target') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
 
     - name: Prepare for license check
       run: ${{ inputs.setupScript }}


### PR DESCRIPTION
Update to run the license-check build with Java-17.
Tycho soon requires Java-17 and since it participates in the dependency resolution Java-17 will then be required.
Since no regular part of the build is executed, using Java-17 here should not be a problem for projects that are regularly build with earlier Java versions.

Additionally consider *.target files for caching dependencies, not only pom.xml files, because the target-file also controls required dependencies.

@waynebeaton please review and merge this. Thank you.