### PR TITLE
Support checkout/processing of git-submodules in license-check workflow

### DIFF
--- a/.github/workflows/mavenLicenseCheck.yml
+++ b/.github/workflows/mavenLicenseCheck.yml
@@ -25,6 +25,14 @@ on:
         type: string
         required: false
         default: ''
+      submodules:
+        description: |
+          Whether to checkout submodules: `true` to checkout submodules or `recursive` to recursively checkout submodules.
+          When the `ssh-key` input is not provided, SSH URLs beginning with `git@github.com:` are converted to HTTPS.
+          The value is just passed as it is to the github/actions/checkout action: https://github.com/actions/checkout#usage
+        type: string
+        required: false
+        default: 'false'
     secrets:
       gitlabAPIToken:
         description: 'The authentication token (scope: api) from gitlab.eclipse.org of the calling repository. Only required if license vetting is requested'
@@ -69,11 +77,14 @@ jobs:
     - uses: actions/checkout@v3
       # use default ref 'refs/pull/<PR-number>/merge' for PR-events and 'refs/heads/master' for comments if the PR is closed
       if: github.event.issue.pull_request == '' || github.event.issue.state != 'open'
+      with:
+        submodules: ${{ inputs.submodules }}
     - uses: actions/checkout@v3
       with:
         ref: 'refs/pull/${{ github.event.issue.number }}/merge'
+        submodules: ${{ inputs.submodules }}
       if: github.event.issue.pull_request != '' && github.event.issue.state == 'open'
-  
+
     - uses: actions/setup-java@v3
       with:
         java-version: '17'

--- a/README.md
+++ b/README.md
@@ -437,9 +437,10 @@ jobs:
     with:
       projectId: <PROJECT-ID>
     secrets:
-      gitlabAPIToken: ${{ secrets.M2E_GITLAB_API_TOKEN }}
+      gitlabAPIToken: ${{ secrets.<PROJECT-NAME>_GITLAB_API_TOKEN }}
 ```
 Projects that have to be set up in advance can use the `setupScript` parameter to pass a script that is executed before the license-check build is started.
+Projects that want their git submodules to be checked out and processed can use the 'submodule' parameter.
 
 On each pull-reqest event (i.e. a new PR is created or a new commit for it is pushed) the license-status of all project dependencies is checked automatically and in case unvetted licenses are found the check fails.
 Committers of that project can request a review from the IP team, by simply adding a comment with body `/request-license-review`.


### PR DESCRIPTION
With this PR projects can specify the `submodules` parameters when calling the License workflow to check-out git submodules too when this workflow is about to set up the build environment.
This is for example required for the eclipse.platform.releng.aggregator repo.

@waynebeaton can you please merge this. Thank you in advance!