### PR TITLE
Fix IP review links, so they are clickable from tool's output

### DIFF
--- a/core/src/main/java/org/eclipse/dash/licenses/review/GitLabSupport.java
+++ b/core/src/main/java/org/eclipse/dash/licenses/review/GitLabSupport.java
@@ -80,7 +80,7 @@ public class GitLabSupport {
 					Issue existing = connection.findIssue(review);
 					if (existing != null) {
 						monitor.accept(licenseData.getId(), existing.getWebUrl());
-						logger.info("A review request already exists {}.", existing.getWebUrl());
+						logger.info("A review request already exists {} .", existing.getWebUrl());
 						continue;
 					}
 
@@ -92,7 +92,7 @@ public class GitLabSupport {
 					}
 
 					monitor.accept(licenseData.getId(), created.getWebUrl());
-					logger.info("A review request was created {}.", created.getWebUrl());
+					logger.info("A review request was created {} .", created.getWebUrl());
 				} catch (GitLabApiException e) {
 					throw new RuntimeException(e);
 				}


### PR DESCRIPTION
Running `dash-licenses` in Theia's CI, to automatically create IP reviews for suspicious dependencies, I encountered a small issue.

When such a dependency is found, looking at the log [1] of the tool's run, I tried clicking on the link to the review. However it failed because it takes the end-of-sentence period, immediately following the URL, as being part of it.

This PR adds a space between URL and the period, hopefully fixing the issue.

Fixes #187

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>