### PR TITLE
Add an option to ignore local dependencies

### DIFF
--- a/core/src/main/java/org/eclipse/dash/licenses/cli/CommandLineSettings.java
+++ b/core/src/main/java/org/eclipse/dash/licenses/cli/CommandLineSettings.java
@@ -31,6 +31,7 @@ public class CommandLineSettings implements ISettings {
 	private static final String CONFIDENCE_OPTION = "confidence";
 	private static final String SUMMARY_OPTION = "summary";
 	private static final String REVIEW_OPTION = "review";
+	private static final String IGNORE_LOCALS_OPTION = "ignoreLocals";
 	private static final String TOKEN_OPTION = "token";
 	private static final String PROJECT_OPTION = "project";
 
@@ -151,6 +152,10 @@ public class CommandLineSettings implements ISettings {
 		return commandLine.hasOption(REVIEW_OPTION);
 	}
 
+	public boolean isIgnoreLocals() {
+		return commandLine.hasOption(IGNORE_LOCALS_OPTION);
+	}
+
 	private CommandLineSettings(CommandLine commandLine) {
 		this.commandLine = commandLine;
 	}
@@ -236,6 +241,12 @@ public class CommandLineSettings implements ISettings {
 			.hasArg(false)
 			.desc("Must also specify the project and token")
 			.build());
+
+		options.addOption(Option.builder(IGNORE_LOCALS_OPTION)
+				.required(false)
+				.hasArg(false)
+				.desc("Do not fail oon local dependencies")
+				.build());
 
 		options.addOption(Option.builder(TOKEN_OPTION)
 			.required(false)

--- a/core/src/main/java/org/eclipse/dash/licenses/cli/Main.java
+++ b/core/src/main/java/org/eclipse/dash/licenses/cli/Main.java
@@ -68,7 +68,7 @@ public class Main {
 		List<IResultsCollector> collectors = new ArrayList<>();
 
 		// TODO Set up collectors based on command line parameters
-		IResultsCollector primaryCollector = new NeedsReviewCollector();
+		IResultsCollector primaryCollector = new NeedsReviewCollector(settings.isIgnoreLocals());
 		collectors.add(primaryCollector);
 
 		String summaryPath = settings.getSummaryFilePath();

--- a/core/src/main/java/org/eclipse/dash/licenses/cli/NeedsReviewCollector.java
+++ b/core/src/main/java/org/eclipse/dash/licenses/cli/NeedsReviewCollector.java
@@ -27,14 +27,26 @@ public class NeedsReviewCollector implements IResultsCollector {
 	final Logger logger = LoggerFactory.getLogger(NeedsReviewCollector.class);
 
 	private List<LicenseData> needsReview = new ArrayList<>();
+	private List<LicenseData> manualReview = new ArrayList<>();
+
+	private boolean ignoreLocals = false;
 
 	public NeedsReviewCollector() {
+		this(false);
+	}
+
+	public NeedsReviewCollector(final boolean ignoreLocals) {
+		this.ignoreLocals = ignoreLocals;
 	}
 
 	@Override
 	public void accept(LicenseData data) {
 		if (data.getStatus() != Status.Approved) {
-			needsReview.add(data);
+			if (ignoreLocals && "local".equals(data.getId().getSource())) {
+				manualReview.add(data);
+			} else {
+				needsReview.add(data);
+			}
 		}
 	}
 
@@ -43,11 +55,21 @@ public class NeedsReviewCollector implements IResultsCollector {
 		if (needsReview.isEmpty()) {
 			logger.info("Vetted license information was found for all content. No further investigation is required.");
 		} else {
-			logger.info("License information could not be automatically verified for the following content:");
-			logger.info("");
-			needsReview.stream().map(LicenseData::getId).map(each -> each.toString()).sorted().forEach(logger::info);
-			logger.info("");
-			logger.info("This content is either not correctly mapped by the system, or requires review.");
+			logger.error("License information could not be automatically verified for the following content:");
+			logger.error("");
+			needsReview.stream().map(LicenseData::getId).map(each -> each.toString()).sorted().forEach(logger::error);
+			logger.error("");
+			logger.error("This content is either not correctly mapped by the system, or requires review.");
+		}
+
+		if (ignoreLocals && !manualReview.isEmpty()) {
+			logger.warn("");
+			logger
+					.warn("License information could not be automatically verified for the following manually installed content:");
+			logger.warn("");
+			manualReview.stream().map(LicenseData::getId).map(each -> each.toString()).sorted().forEach(logger::warn);
+			logger.warn("");
+			logger.warn("This content requires a manual review.");
 		}
 	}
 

--- a/core/src/main/java/org/eclipse/dash/licenses/review/CreateReviewRequestCollector.java
+++ b/core/src/main/java/org/eclipse/dash/licenses/review/CreateReviewRequestCollector.java
@@ -38,7 +38,7 @@ public class CreateReviewRequestCollector implements IResultsCollector {
 
 	@Override
 	public void accept(LicenseData data) {
-		if (data.getStatus() != Status.Approved) {
+		if (data.getStatus() != Status.Approved && !"local".equals(data.getId().getSource())) {
 			needsReview.add(data);
 		}
 	}


### PR DESCRIPTION
The option `-ignoreLocals` is added in order to not fail on dependencies which ID Source == `local`. The change makes dash-license Java application to:
- NEVER create a review request for such a 'local' dependency (as it's actually not possible to resolve them automatically)
- NOT to fail on exit when `-ingoreLocals` option is  used and there's only 'local' dependencues found not resolved
- NOT to count `local` dependencies (The couunting gows and reviews are created on;y for the dependencies that are NOT `local')
- to WARN on 'local' dependencies found separately from the other kinds of dependencies

In case of NO `-ignoreLocals` option used any not resolved dependencies are listed as a single list and reported as ERRORS, however the reviews are creted for only the dependencies that are NOT `local`