### PR TITLE
[Vetting-Workflow] Requests license review for dependabot PRs automatically

### DIFF
--- a/.github/actions/maven-license-check-action/action.yml
+++ b/.github/actions/maven-license-check-action/action.yml
@@ -1,11 +1,12 @@
 # *************************************************************************
-# * Copyright (c) 2022 Hannes Wellmann and others.
+# * Copyright (c) 2022, 2023 Hannes Wellmann and others.
 # *
 # * This program and the accompanying materials are made available under
 # * the terms of the Eclipse Public License 2.0 which accompanies this
 # * distribution, and is available at https://www.eclipse.org/legal/epl-2.0
 # *
 # * SPDX-License-Identifier: EPL-2.0
+# *      Hannes Wellmann - initial API and implementation
 # *************************************************************************
 
 name: 'Check license vetting status'
@@ -24,7 +25,9 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - run: |
+    - id: license-check-with-review-request
+      shell: bash {0} # do not fail-fast
+      run: |
         mvnArgs="-U -B -ntp org.eclipse.dash:license-tool-plugin:license-check -Ddash.fail=true --settings $GITHUB_ACTION_PATH/licenseCheckMavenSettings.xml"
         if [ ${{ inputs.request-review }} ]; then
           mvn ${mvnArgs} -Ddash.iplab.token=$GITLAB_API_TOKEN -Ddash.projectId=${{ inputs.project-id }}
@@ -40,5 +43,3 @@ runs:
             exit 1
           fi
         fi
-      shell: bash {0} # do not fail-fast
-      id: license-check-with-review-request

--- a/.github/workflows/mavenLicenseCheck.yml
+++ b/.github/workflows/mavenLicenseCheck.yml
@@ -1,11 +1,12 @@
 # *************************************************************************
-# * Copyright (c) 2022 Hannes Wellmann and others.
+# * Copyright (c) 2022, 2023 Hannes Wellmann and others.
 # *
 # * This program and the accompanying materials are made available under
 # * the terms of the Eclipse Public License 2.0 which accompanies this
 # * distribution, and is available at https://www.eclipse.org/legal/epl-2.0
 # *
 # * SPDX-License-Identifier: EPL-2.0
+# *      Hannes Wellmann - initial API and implementation
 # *************************************************************************
 
 # This workflow will check for Maven projects if the licenses of all (transitive) dependencies are vetted.
@@ -45,13 +46,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+    - name: Check dependabot PR 
+      run: echo "isDependabotPR=1" >> $GITHUB_ENV
+      if: >
+        github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'synchronize' || github.event.action == 'reopened')
+        && github.actor == 'dependabot[bot]' && github.actor_id == '49699333'
+      # For 'issue_comment'-events this job only runs if a comment was added to a PR with body specified above
+
     - name: Set review request
       run: echo "request-review=1" >> $GITHUB_ENV
-      if: github.event_name == 'issue_comment'
+      if: github.event_name == 'issue_comment' || env.isDependabotPR
       # For 'issue_comment'-events this job only runs if a comment was added to a PR with body specified above
 
     - name: Process license-vetting request
-      if: env.request-review
+      if: env.request-review && (!env.isDependabotPR)
       uses: actions/github-script@v6
       with:
         script: |
@@ -119,7 +127,13 @@ jobs:
           const fs = require('fs')
           
           const licenesVetted = ${{ steps.check-license-vetting.outputs.licenses-vetted }}
-          let commentBody = '> ' + context.payload.comment.body + '\n\n'
+          let commentBody = ''
+          if ( context.payload.comment ) {
+            commentBody += '> ' + context.payload.comment.body + '\n\n'
+          } else if ( licenesVetted ){
+            core.info('License review request made automatically but all licenses are already vetted.')
+            return; // Don't create a comment in this case, the checks in the UI indicate the state already.
+          }
           
           if( licenesVetted ) {
             commentBody += ':heavy_check_mark: All licenses already successfully vetted.\n'


### PR DESCRIPTION
Work in progress to change the re-usable license-vetting workflow to automatically create license review requests for PRs opened by dependabot.

FYI @laeubi