### PR TITLE
Adding custom ort configuration file for repository.

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -1,0 +1,5 @@
+excludes:
+  paths:
+  - pattern: "core/src/test/java/**"
+    reason: "TEST_OF"
+    comment: "This directory contains licence test data which are not distributed."


### PR DESCRIPTION
This is to add a new file `.ort.yml` to the dash-license repo to test the custom ort configuration file. See https://gitlab.eclipse.org/eclipsefdn/emo-team/eclipsefdn-ort/-/issues/76