### PR TITLE
[Workflow] Always pass projectId property to the license-tool-plugin and use GITHUB_OUTPUT environment-file

### DIFF
--- a/.github/actions/maven-license-check-action/action.yml
+++ b/.github/actions/maven-license-check-action/action.yml
@@ -32,9 +32,9 @@ runs:
         if [ ${{ inputs.request-review }} ]; then
           mvn ${mvnArgs} -Ddash.iplab.token=$GITLAB_API_TOKEN -Ddash.projectId=${{ inputs.project-id }}
           if [[ $? == 0 ]]; then # All licenses are vetted
-            echo "::set-output name=build-succeeded::$(echo 1)"
+            echo "build-succeeded=1" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=build-succeeded::$(echo 0)"
+            echo "build-succeeded=0" >> $GITHUB_OUTPUT
           fi
         else
           mvn ${mvnArgs}

--- a/.github/actions/maven-license-check-action/action.yml
+++ b/.github/actions/maven-license-check-action/action.yml
@@ -29,8 +29,11 @@ runs:
       shell: bash {0} # do not fail-fast
       run: |
         mvnArgs="-U -B -ntp org.eclipse.dash:license-tool-plugin:license-check -Ddash.fail=true -Dtycho.target.eager=true --settings $GITHUB_ACTION_PATH/licenseCheckMavenSettings.xml"
+        if [[ ${{ inputs.project-id }} != "" ]]; then
+          mvnArgs+=" -Ddash.projectId=${{ inputs.project-id }}"
+        fi
         if [ ${{ inputs.request-review }} ]; then
-          mvn ${mvnArgs} -Ddash.iplab.token=$GITLAB_API_TOKEN -Ddash.projectId=${{ inputs.project-id }}
+          mvn ${mvnArgs} -Ddash.iplab.token=$GITLAB_API_TOKEN
           if [[ $? == 0 ]]; then # All licenses are vetted
             echo "build-succeeded=1" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
Always pass `projectId` property to the license-tool-plugin, if the property is set, fixes https://github.com/eclipse/dash-licenses/issues/233

Use `GITHUB_OUTPUT` environment-file to set check output, fixes https://github.com/eclipse/dash-licenses/issues/234

I did not yet test this change and will probably not have to the time to do it before next week.

@jonahgraham if you want to test it earlier you can reference it with `uses: HannesWell/dash-licenses/.github/workflows/mavenLicenseCheck.yml@fix233`, but I would suggest to not push such workflow to the master/main then.