### PR TITLE
Add arguments to enforce eager resolution in case of Tycho builds

### DIFF
--- a/.github/actions/maven-license-check-action/action.yml
+++ b/.github/actions/maven-license-check-action/action.yml
@@ -28,7 +28,7 @@ runs:
     - id: license-check-with-review-request
       shell: bash {0} # do not fail-fast
       run: |
-        mvnArgs="-U -B -ntp org.eclipse.dash:license-tool-plugin:license-check -Ddash.fail=true --settings $GITHUB_ACTION_PATH/licenseCheckMavenSettings.xml"
+        mvnArgs="-U -B -ntp org.eclipse.dash:license-tool-plugin:license-check -Ddash.fail=true -Dtycho.target.eager=true --settings $GITHUB_ACTION_PATH/licenseCheckMavenSettings.xml"
         if [ ${{ inputs.request-review }} ]; then
           mvn ${mvnArgs} -Ddash.iplab.token=$GITLAB_API_TOKEN -Ddash.projectId=${{ inputs.project-id }}
           if [[ $? == 0 ]]; then # All licenses are vetted


### PR DESCRIPTION
This adds an arguments that are required for Tycho 4+ to fulfill the expectation of the dash-license tool that all dependencies are know even if no project is ever executed:

-Dtycho.target.eager=true ask Tycho to resolve the dependencies of a project and dynamically inject them into the maven model before any other plugin is executed