### PR TITLE
[Maven-Plugin] Lazy resolve project dependencies and execute per project

### DIFF
--- a/.github/actions/maven-license-check-action/action.yml
+++ b/.github/actions/maven-license-check-action/action.yml
@@ -18,6 +18,9 @@ inputs:
   project-id:
     description: ''
     required: false
+  extra-maven-arguments:
+    description: ''
+    required: false
 outputs:
   licenses-vetted: 
     description: "True if all licenses are vetted, else false"
@@ -28,7 +31,7 @@ runs:
     - id: license-check-with-review-request
       shell: bash {0} # do not fail-fast
       run: |
-        mvnArgs="-U -B -ntp org.eclipse.dash:license-tool-plugin:license-check -Ddash.fail=true -Dtycho.target.eager=true --settings $GITHUB_ACTION_PATH/licenseCheckMavenSettings.xml"
+        mvnArgs="${{ inputs.extra-maven-arguments }} -U -B -ntp org.eclipse.dash:license-tool-plugin:license-check -Ddash.fail=true --settings $GITHUB_ACTION_PATH/licenseCheckMavenSettings.xml"
         if [[ ${{ inputs.project-id }} != "" ]]; then
           mvnArgs+=" -Ddash.projectId=${{ inputs.project-id }}"
         fi

--- a/.github/workflows/mavenLicenseCheck.yml
+++ b/.github/workflows/mavenLicenseCheck.yml
@@ -26,6 +26,11 @@ on:
         type: string
         required: false
         default: ''
+      extraMavenArguments:
+        description: 'Optional additional arguments passed to the Maven command to launch license check build'
+        type: string
+        required: false
+        default: ''
       submodules:
         description: |
           Whether to checkout submodules: `true` to checkout submodules or `recursive` to recursively checkout submodules.
@@ -116,6 +121,7 @@ jobs:
       with:
         request-review: ${{ env.request-review }}
         project-id: ${{ inputs.projectId }}
+        extra-maven-arguments: ${{ inputs.extraMavenArguments }}
       env:
         GITLAB_API_TOKEN: ${{ secrets.gitlabAPIToken }}
 


### PR DESCRIPTION
This approach has the following advantages:
- Eager resolution is not required for Tycho
- One can simply run other phases/goal in the same build which is helpful for mixed reactors with Eclipse Plugin projects and 'pure' Maven projects.
- The license-check mojo can be run as part of the regular build only for selected projects
- The dependency resolution can be parallelized

The actual checks are still performed in the end on the set of all collected artifacts and only once for each artifacts to keep the network traffic small.