### PR TITLE
Configure explicit maven version (and use maven 3.9.2) -- Updated

### DIFF
--- a/.github/workflows/mavenLicenseCheck.yml
+++ b/.github/workflows/mavenLicenseCheck.yml
@@ -34,6 +34,11 @@ on:
         type: string
         required: false
         default: 'false'
+      mavenVersion: 
+        description: 'The version of Maven set up to run the license-check build'
+        type: string
+        required: false
+        default: '3.9.2'
     secrets:
       gitlabAPIToken:
         description: 'The authentication token (scope: api) from gitlab.eclipse.org of the calling repository. Only required if license vetting is requested'
@@ -105,6 +110,11 @@ jobs:
         key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml', '**/*.target') }}
         restore-keys: |
           ${{ runner.os }}-maven-
+
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v4.5
+      with:
+        maven-version: ${{ inputs.mavenVersion }}
 
     - name: Prepare for license check
       run: ${{ inputs.setupScript }}


### PR DESCRIPTION
Replacement for https://github.com/eclipse/dash-licenses/pull/244, that contains the suggested changes from https://github.com/eclipse/dash-licenses/pull/244#pullrequestreview-1473722639.

The advantage compared to the mentioned PR is that the `mavenVersion` is now a parameter of the reusable workflow and thus callers can set specify it in their workflow calls. Additionally the maven version is now also configured for the setupScript that can run before the actual license-check build (I don't know if anyone uses it, I introduced it for M2E, but we don't need it there anymore).