### PR TITLE
Add Github Workflow to verify PRs and pushes to the master branch

### DIFF
--- a/.github/workflows/mavenBuild.yml
+++ b/.github/workflows/mavenBuild.yml
@@ -1,0 +1,32 @@
+# This workflow will build the dash-licenes project with Maven
+
+name: Build dash-licenes
+on:
+  push:
+    branches: 
+      - 'master'
+  pull_request:
+    branches: 
+     - 'master'
+
+jobs:
+  build:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+
+    steps:
+    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      with:
+        fetch-depth: 0
+        submodules: true
+    - uses: actions/setup-java@cd89f46ac9d01407894225f350157564c9c7cee2 # v3.12.0
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: 'maven'
+    - run: mvn clean verify


### PR DESCRIPTION
As suggested in https://github.com/eclipse/dash-licenses/pull/264#issuecomment-1688107924, this adds a first basic verification maven build for PR's and pushes to master.

Later it could be enhanced with sub-sequent workflows that for example use the just build license-check maven plugin for selected projects as part of the verification.

While the maven-plugin probably usually runs in the CI on Linux users can also run it locally on any OS. And since the builds are very quick, I think it is ok to run the build and tests on all three major OS.