### PR TITLE
[License-Check-Workflow] explicitly specify least required permission

### DIFF
--- a/.github/workflows/mavenLicenseCheck.yml
+++ b/.github/workflows/mavenLicenseCheck.yml
@@ -49,6 +49,8 @@ jobs:
     if: github.event_name != 'issue_comment' || ( github.event.issue.pull_request != '' && (github.event.comment.body == '/request-license-review') )
     # Run on all non-comment events specified by the calling workflow and for comments on PRs that have a corresponding body.
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
 
     - name: Check dependabot PR 


### PR DESCRIPTION
This also helps callers in repositories with stricter default permissions to identify the permissions that are required.

In order to identify the required permissions I used [GitHub's token permissions Monitor action](https://github.com/GitHubSecurityLab/actions-permissions/tree/main/monitor), which is currently in public beta.