### PR TITLE
[License-Workflow] Fail workflow on automated vetting-requests

### DIFF
--- a/.github/workflows/mavenLicenseCheck.yml
+++ b/.github/workflows/mavenLicenseCheck.yml
@@ -145,11 +145,15 @@ jobs:
           
           const licenesVetted = ${{ steps.check-license-vetting.outputs.licenses-vetted }}
           let commentBody = ''
+          // if context.payload.comment is empty, this is an explicit review-request through a comment, if not an automated one, e.g. for dependabot PRs
           if ( context.payload.comment ) {
             commentBody += '> ' + context.payload.comment.body + '\n\n'
           } else if ( licenesVetted ){
             core.info('License review request made automatically but all licenses are already vetted.')
             return; // Don't create a comment in this case, the checks in the UI indicate the state already.
+          } else {
+            // This run encountered pending reviews, which have been requested automatically, e.g. for dependabot PRs
+            core.setFailed("Some dependencies must be vetted and their review was requested. Rerun this check once these reviews succeeded.")
           }
           
           if( licenesVetted ) {


### PR DESCRIPTION
Since https://github.com/eclipse/dash-licenses/pull/220 license-reviews are automatically requested for PRs created by dependabot. But in that change the logic of the 'Process license check results' step was not updated to consider that case. This had the effect that the license-vetting workflow always succeeded for PRs created by dependabot.

The intention to not fail the workflow in general when a license-review was requested is because initially review-request were only created manually from committers by adding a corresponding comment to the PR. And that workflow execution should not fail respectively its result was actually irrelevant.

Fixes https://github.com/eclipse-tycho/tycho/issues/3661