### PR TITLE
Update default Maven version to 3.9.11

### DIFF
--- a/.github/workflows/mavenLicenseCheck.yml
+++ b/.github/workflows/mavenLicenseCheck.yml
@@ -38,7 +38,7 @@ on:
         description: 'The version of Maven set up to run the license-check build'
         type: string
         required: false
-        default: '3.9.6'
+        default: '3.9.11'
       javaVersion:
         description: 'The version of Java set up to run the license-check build'
         type: string


### PR DESCRIPTION
3.9.6 is rather old, using the latest maven 3.9 release instead.