### PR TITLE
Update setup-maven gha to Node 24 compatible version

### DIFF
--- a/.github/workflows/mavenLicenseCheck.yml
+++ b/.github/workflows/mavenLicenseCheck.yml
@@ -124,7 +124,7 @@ jobs:
           ${{ runner.os }}-maven-
 
     - name: Set up Maven
-      uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
+      uses: stCarolas/setup-maven@12eb41b233df95d49b0c11fc1b5bc8312e5d4ce0 # v5.1
       with:
         maven-version: ${{ inputs.mavenVersion }}
 


### PR DESCRIPTION
This should fix warnings like
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/actions/runs/24762227400 :
```
 call-license-check / check-licenses
Node.js 20 actions are deprecated. The following actions are running on
Node.js 20 and may not work as expected:
stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1. Actions
will be forced to run with Node.js 24 by default starting June 2nd,
2026. Node.js 20 will be removed from the runner on September 16th,
2026. Please check if updated versions of these actions are available
that support Node.js 24. To opt into Node.js 24 now, set the
FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the
runner or in your workflow file. Once Node.js 24 becomes the default,
you can temporarily opt out by setting
ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```